### PR TITLE
Fix the lack fo absolute URLs in the RSS feed.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ email: chris.phillips@uk.ibm.com
 description: API, Integration and Governance SME and Enthusiast, My opinions are very much mine
 #An blog on APIs and other interesting Technology
 baseurl: "/" # the subpath of your site, e.g. /blog
-url: ""
+url: "https://chrisphillips-cminion.github.io/"
 
 highlighter: rouge
 excerpt_separator: <!--more-->


### PR DESCRIPTION
According to the [docs](https://github.com/jekyll/jekyll-feed#optional-configuration-options) of the `jekyll-feed` it will use the `url` attribute of the config.yaml as the URL. In this case, it needs to have a value other than an empty string.

**Full disclosure, I have no idea if this will create issues on other parts of the blog.**